### PR TITLE
Fix the optional WebminCore load

### DIFF
--- a/build-devel-rpm.sh
+++ b/build-devel-rpm.sh
@@ -31,5 +31,5 @@ perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "
 # Copy to build/deploy server
 scp -i "${HOME}/.ssh/id_ed25519" "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
 # Add it to the publish queue
-ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue.lock echo 'vm/7/gpl-devel/rpm/noarch' >> /home/build/rpm-publish-queue"
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch >> /home/build/rpm-publish-queue'"
 

--- a/jailkit-lib.pl
+++ b/jailkit-lib.pl
@@ -19,7 +19,10 @@ directives from jk_init.ini.
 BEGIN { push(@INC, ".."); }
 if (eval {require WebminCore;1;} ne 1) {
   exit 1;
+} else {
+  WebminCore->import();
 }
+
 init_config();
 
 =head2 get_jk_init_ini()


### PR DESCRIPTION
Makes the module actually work after install. But can also run tests without WebminCore being available.