### PR TITLE
Only build stable on version change and in `virtualmin` repo

### DIFF
--- a/.github/workflows/build-devel-deb.yaml
+++ b/.github/workflows/build-devel-deb.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    if: github.repository == 'virtualmin/*'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-devel-rpm.yaml
+++ b/.github/workflows/build-devel-rpm.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    if: github.repository == 'virtualmin/*'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-stable-deb.yaml
+++ b/.github/workflows/build-stable-deb.yaml
@@ -1,0 +1,27 @@
+name: "build-stabledeb"
+
+on:
+  push:
+    branches:
+      - stable
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: 'jailkit'
+
+      - name: Install dependencies
+        run: |-
+          sudo apt-get -y update
+          sudo apt-get -y install perl build-essential gnupg curl
+          curl -O https://raw.githubusercontent.com/webmin/webmin/master/mod_def_list.txt
+          curl -O https://raw.githubusercontent.com/webmin/webmin/master/makemoduledeb.pl
+      - name: Build package
+        env:
+          APTLY_USER: ${{ secrets.APTLY_USER }}
+          APTLY_PASSWD: ${{ secrets.APTLY_PASSWD }}
+        run: |-
+          jailkit/build-stable-deb.sh

--- a/.github/workflows/build-stable-deb.yaml
+++ b/.github/workflows/build-stable-deb.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    if: github.repository == 'virtualmin/*'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-stable-deb.yaml
+++ b/.github/workflows/build-stable-deb.yaml
@@ -1,9 +1,11 @@
-name: "build-stabledeb"
+name: "build-stable-deb"
 
 on:
   push:
     branches:
       - stable
+    paths:
+      - 'module.info'
 
 jobs:
   build:

--- a/.github/workflows/build-stable-rpm.yaml
+++ b/.github/workflows/build-stable-rpm.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    if: github.repository == 'virtualmin/*'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-stable-rpm.yaml
+++ b/.github/workflows/build-stable-rpm.yaml
@@ -3,7 +3,9 @@ name: "build-devel-rpm"
 on:
   push:
     branches:
-      - stable 
+      - stable
+    paths:
+      - 'module.info'
 
 jobs:
   build:

--- a/.github/workflows/build-stable-rpm.yaml
+++ b/.github/workflows/build-stable-rpm.yaml
@@ -1,0 +1,34 @@
+name: "build-devel-rpm"
+
+on:
+  push:
+    branches:
+      - stable 
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: 'jailkit'
+
+      - name: Install dependencies
+        run: |-
+          sudo apt-get -y update
+          sudo apt-get -y install rpm perl build-essential gnupg curl
+          curl -O https://raw.githubusercontent.com/webmin/webmin/master/mod_def_list.txt
+          curl -O https://raw.githubusercontent.com/webmin/webmin/master/makemodulerpm.pl
+      - name: Setup ssh
+        env:
+          BUILD_SSH_PRIVATE_KEY: ${{ secrets.BUILD_SSH_PRIVATE_KEY }}
+          BUILD_SSH_KNOWN_HOSTS: ${{ secrets.BUILD_SSH_KNOWN_HOSTS }}
+        run: |-
+          install -m 600 -D /dev/null ~/.ssh/id_ed25519
+          echo "${{ secrets.BUILD_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          echo "${{ secrets.BUILD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+      - name: Build package
+        env:
+          BUILD_SSH_USER: ${{ secrets.BUILD_SSH_USER }}
+        run: |-
+          jailkit/build-stable-rpm.sh

--- a/build-devel-rpm.sh
+++ b/build-devel-rpm.sh
@@ -29,7 +29,8 @@ ls "${HOME}/rpmbuild/SPECS"
 perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "$MOD" "$VERSION"
 
 # Copy to build/deploy server
-scp -i "${HOME}/.ssh/id_ed25519" "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
+chmod g+w "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm"
+scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
 # Add it to the publish queue
 ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
 

--- a/build-devel-rpm.sh
+++ b/build-devel-rpm.sh
@@ -31,5 +31,5 @@ perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "
 # Copy to build/deploy server
 scp -i "${HOME}/.ssh/id_ed25519" "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
 # Add it to the publish queue
-ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch >> /home/build/rpm-publish-queue'"
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
 

--- a/build-stable-deb.sh
+++ b/build-stable-deb.sh
@@ -7,12 +7,9 @@ set -xeu
 MOD='jailkit'
 NAME="webmin-$MOD"
 
-# Always increasing. Also a human-readable datetime.
-BUILD=$(date +'%Y%m%d%H%M')
-
 # Load module.info to get version
 version=$(grep version $MOD/module.info | cut -d'=' -f2)
-VERSION="${version}.${BUILD}"
+VERSION="${version}"
 
 mkdir tmp
 perl makemoduledeb.pl --deb-depends --licence 'GPLv3' --email 'joe@virtualmin.com' --allow-overwrite --target-dir tmp "$MOD" "$VERSION"

--- a/build-stable-deb.sh
+++ b/build-stable-deb.sh
@@ -20,5 +20,8 @@ mv "tmp/${NAME}_${VERSION}_all.deb" .
 
 # Publish to aptly
 curl --user $APTLY_USER:$APTLY_PASSWD -X POST -F file=@${NAME}_${VERSION}_all.deb https://aptly.virtualmin.com/api/files/${NAME}_${VERSION}
-curl --user $APTLY_USER:$APTLY_PASSWD -X POST https://aptly.virtualmin.com/api/repos/virtualmin-7-gpl-devel/file/${NAME}_${VERSION}
-curl -i --user $APTLY_USER:$APTLY_PASSWD -X PUT -H 'Content-Type: application/json' --data '{}' https://aptly.virtualmin.com/api/publish/filesystem:7-gpl:./virtualmin-devel
+curl --user $APTLY_USER:$APTLY_PASSWD -X POST https://aptly.virtualmin.com/api/repos/virtualmin-7-gpl/file/${NAME}_${VERSION}
+curl -i --user $APTLY_USER:$APTLY_PASSWD -X PUT -H 'Content-Type: application/json' --data '{}' https://aptly.virtualmin.com/api/publish/filesystem:7-gpl:./virtualmin
+curl --user $APTLY_USER:$APTLY_PASSWD -X POST -F file=@${NAME}_${VERSION}_all.deb https://aptly.virtualmin.com/api/files/${NAME}_${VERSION}
+curl --user $APTLY_USER:$APTLY_PASSWD -X POST https://aptly.virtualmin.com/api/repos/virtualmin-gpl-universal/file/${NAME}_${VERSION}
+curl -i --user $APTLY_USER:$APTLY_PASSWD -X PUT -H 'Content-Type: application/json' --data '{}' https://aptly.virtualmin.com/api/publish/filesystem:gpl:./virtualmin-universal

--- a/build-stable-deb.sh
+++ b/build-stable-deb.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Build and publish a package, called by github actions
+
+# echo, exit on error/undefined vars
+set -xeu
+
+MOD='jailkit'
+NAME="webmin-$MOD"
+
+# Always increasing. Also a human-readable datetime.
+BUILD=$(date +'%Y%m%d%H%M')
+
+# Load module.info to get version
+version=$(grep version $MOD/module.info | cut -d'=' -f2)
+VERSION="${version}.${BUILD}"
+
+mkdir tmp
+perl makemoduledeb.pl --deb-depends --licence 'GPLv3' --email 'joe@virtualmin.com' --allow-overwrite --target-dir tmp "$MOD" "$VERSION"
+mv "tmp/${NAME}_${VERSION}_all.deb" .
+
+# Publish to aptly
+curl --user $APTLY_USER:$APTLY_PASSWD -X POST -F file=@${NAME}_${VERSION}_all.deb https://aptly.virtualmin.com/api/files/${NAME}_${VERSION}
+curl --user $APTLY_USER:$APTLY_PASSWD -X POST https://aptly.virtualmin.com/api/repos/virtualmin-7-gpl-devel/file/${NAME}_${VERSION}
+curl -i --user $APTLY_USER:$APTLY_PASSWD -X PUT -H 'Content-Type: application/json' --data '{}' https://aptly.virtualmin.com/api/publish/filesystem:7-gpl:./virtualmin-devel

--- a/build-stable-rpm.sh
+++ b/build-stable-rpm.sh
@@ -7,12 +7,9 @@ set -xeu
 MOD='jailkit'
 NAME="wbm-$MOD"
 
-# Always increasing. Also a human-readable datetime.
-BUILD=$(date +'%Y%m%d%H%M')
-
 # Load module.info to get version
 version=$(grep version $MOD/module.info | cut -d'=' -f2)
-VERSION="${version}.${BUILD}"
+VERSION="${version}"
 
 if [ -f epoch ]; then
 	epoch="--epoch $(cat epoch)"

--- a/build-stable-rpm.sh
+++ b/build-stable-rpm.sh
@@ -28,5 +28,5 @@ perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "
 # Copy to build/deploy server
 scp -i "${HOME}/.ssh/id_ed25519" "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
 # Add it to the publish queue
-ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch >> /home/build/rpm-publish-queue'"
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
 

--- a/build-stable-rpm.sh
+++ b/build-stable-rpm.sh
@@ -26,7 +26,8 @@ mkdir -p "${HOME}/rpmbuild/RPMS/noarch"
 perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "$MOD" "$VERSION"
 
 # Copy to build/deploy server
-scp -i "${HOME}/.ssh/id_ed25519" "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
+chmod g+w "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm"
+scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
 # Add it to the publish queue
 ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
 

--- a/build-stable-rpm.sh
+++ b/build-stable-rpm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Build and publish a package, called by github actions
+
+# echo, exit on error/undefined vars
+set -xeu
+
+MOD='jailkit'
+NAME="wbm-$MOD"
+
+# Always increasing. Also a human-readable datetime.
+BUILD=$(date +'%Y%m%d%H%M')
+
+# Load module.info to get version
+version=$(grep version $MOD/module.info | cut -d'=' -f2)
+VERSION="${version}.${BUILD}"
+
+if [ -f epoch ]; then
+  epoch="--epoch $(cat epoch)"
+else
+  epoch=""
+fi
+
+# FIXME after PR is merged to Webmin
+mkdir -p ${HOME}/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+mkdir -p "${HOME}/rpmbuild/RPMS/noarch"
+perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "$MOD" "$VERSION"
+
+# Copy to build/deploy server
+scp -i "${HOME}/.ssh/id_ed25519" "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
+# Add it to the publish queue
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch >> /home/build/rpm-publish-queue'"
+

--- a/build-stable-rpm.sh
+++ b/build-stable-rpm.sh
@@ -15,9 +15,9 @@ version=$(grep version $MOD/module.info | cut -d'=' -f2)
 VERSION="${version}.${BUILD}"
 
 if [ -f epoch ]; then
-  epoch="--epoch $(cat epoch)"
+	epoch="--epoch $(cat epoch)"
 else
-  epoch=""
+	epoch=""
 fi
 
 # FIXME after PR is merged to Webmin
@@ -27,7 +27,8 @@ perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "
 
 # Copy to build/deploy server
 chmod g+w "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm"
-scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl-devel/rpm/noarch"
+scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl/rpm/noarch"
+scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/6/gpl/rpm/noarch"
 # Add it to the publish queue
-ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl-devel/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
-
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/6/gpl/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"

--- a/build-stable-rpm.sh
+++ b/build-stable-rpm.sh
@@ -28,7 +28,7 @@ perl makemodulerpm.pl --rpm-depends --licence 'GPLv3' --allow-overwrite $epoch "
 # Copy to build/deploy server
 chmod g+w "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm"
 scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/7/gpl/rpm/noarch"
-scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/6/gpl/rpm/noarch"
+scp -i "${HOME}/.ssh/id_ed25519" -p "${HOME}/rpmbuild/RPMS/noarch/${NAME}-${VERSION}-1.noarch.rpm" "$BUILD_SSH_USER@build.virtualmin.com:/home/build/result/vm/6/gpl/universal"
 # Add it to the publish queue
 ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/7/gpl/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
-ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/6/gpl/rpm/noarch/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"
+ssh -i "${HOME}/.ssh/id_ed25519" "$BUILD_SSH_USER@build.virtualmin.com" "flock /home/build/rpm-publish-queue -c 'echo vm/6/gpl/universal/${NAME}-${VERSION}-1.noarch.rpm >> /home/build/rpm-publish-queue'"

--- a/module.info
+++ b/module.info
@@ -2,4 +2,4 @@ name=Jailkit
 desc=Jailkit Jail Manager
 os_support=*-linux
 category=system
-version=0.7
+version=0.8

--- a/module.info
+++ b/module.info
@@ -2,4 +2,4 @@ name=Jailkit
 desc=Jailkit Jail Manager
 os_support=*-linux
 category=system
-version=0.8
+version=0.9


### PR DESCRIPTION
Hopefully, this will make the following changes:

1. Only build stable packages if the module.info has changed (hopefully indicating someone remembered to bump the version).
2. Removes date string from the stable package version (since we will hopefully always have a new human selected version).
3. Only build packages if it's on the `virtualmin` repo, not forks. Tests still run on forks, so people can see if they've made a silly mistake, like syntax errors. Forks shouldn't have valid secrets for our repos, so even if it builds on a fork it can't actually publish, but no reason to chew CPU cycles for nothing.
4. Fixes some problems with publishing (permissions and ownership), so the build server user can operate on files created by the actions user.
5. Changes the publish queue path to be the full file path. The publisher splits it at run time so it can both sign the package with the right key for each repo, and publish any repos with changes.

Hopefully this is the last of the bits needed before I start replicating this out to all Virtualmin module repos. 